### PR TITLE
PER Module

### DIFF
--- a/elegantrl/BetaWarning/run.py
+++ b/elegantrl/BetaWarning/run.py
@@ -138,24 +138,29 @@ def run__demo():
     dir(pybullet_envs)
     # args.env = decorate_env(gym.make('AntBulletEnv-v0'))
     args.env = prep_env(gym.make('ReacherBulletEnv-v0'))
+    # args.repeat_times=8
+    # args.max_memo=args.target_step =4096
 
-    args.break_step = int(4e4 * 8)  # (4e4) 8e5, UsedTime: (300s) 700s
+    args.break_step = int(4e8)  # (4e4) 8e5, UsedTime: (300s) 700s
+    args.if_break_early = False
     args.eval_times1 = 2 ** 2
     args.eval_times1 = 2 ** 4
 
     args.rollout_num = 4
     train_and_evaluate__multiprocessing(args)
 
-    """DEMO 5: Discrete action env: CartPole-v0 of gym"""
+
+    # """DEMO 5: Discrete action env: CartPole-v0 of gym"""
     import pybullet_envs  # for python-bullet-gym
-    args = Arguments(agent_rl=None, env=None, gpu_id=1)  # see Arguments() to see hyper-parameters
+    args = Arguments(agent_rl=None, env=None, gpu_id=0)  # see Arguments() to see hyper-parameters
     args.agent_rl = agent.AgentTD3  # choose an DRL algorithm
     args.env = prep_env(env=gym.make('ReacherBulletEnv-v0'))
     args.net_dim = 2 ** 7  # change a default hyper-parameters
     args.if_per = True
     args.break_step = int(2e20)  # (4e4) 8e5, UsedTime: (300s) 700s
 
-    train_and_evaluate(args)
+    # train_and_evaluate(args)
+    train_and_evaluate__multiprocessing(args)
     exit(0)
 
     # args = Arguments(if_on_policy=True)  # on-policy has different hyper-parameters from off-policy
@@ -688,6 +693,7 @@ def mp__update_params(args, pipe1_eva, pipe1_exp_list):
     reward_scale = args.reward_scale
     break_step = args.break_step
     if_break_early = args.if_break_early
+    if_per=args.if_per
     del args  # In order to show these hyper-parameters clearly, I put them above.
 
     '''init: env'''
@@ -703,6 +709,7 @@ def mp__update_params(args, pipe1_eva, pipe1_exp_list):
 
     buffer_mp = ReplayBufferMP(max_memo + max_step * rollout_num, state_dim,
                                if_on_policy=if_on_policy,
+                               if_per=if_per,
                                action_dim=1 if if_discrete else action_dim,
                                rollout_num=rollout_num)  # build experience replay buffer
 


### PR DESCRIPTION
1. 修正PER的代码有错的地方。Sumtree中empty的错误使用等。此外，修改了SumTree部分命名
 - PER 实现里，buffer满后，添加数据依照遵循先进先出的原则，而不受优先级影响
 - SumTree的叶子结点idx与buffer的idx一一对应，因此可以buffer专注存数据，Sumtree专注存优先级信息。
 - SumTree是完全二叉树，大小是2*buffer_len倍，idx的前 buffer_len-1个是父节点，后buffer_len个是叶子结点。
 - ISWeight的计算按照PER论文伪代码

2. 完成PER的并行功能：
- 在Replaybuffer的extend_memo添加PER
-  在ReplayBufferMP添加batch_update

3. DEMO5是PER-TD的实验。对比TD和PER-TD3的结果。

4. 目前PER只添加在TD3和DQN，PER没问题后，容易在Off oplicy推广

以下英语机翻
1. fix the mistakes in PER's code, the wrong use of empty in SumTree, etc. In addition, modified the naming of SumTree part.
 - In PER implementation, after the buffer is full, the data is added according to the first-in-first-out principle, regardless of the priority.
 - SumTree's leaf node idx corresponds to the idx of buffer one by one, so buffer can focus on storing data and Sumtree on storing priority information.
 - SumTree is a complete binary tree with size 2*buffer_len times, the first buffer_len-1 of idx is the parent node and the next buffer_len is the leaf node.
 - ISWeight is calculated according to the PER paper pseudo code

2. To complete the parallel function of PER.
- Add PER to extend_memo of Replaybuffer
- Add batch_update to ReplayBufferMP

3. DEMO5 is the experiment of PER-TD. Compare the results of TD and PER-TD3. 4.

4. currently PER is only added in TD3 and DQN, after PER is OK, it is easy to promote in Off oplicy


PER-TD多进程采样的DEMO：

`
    
    import pybullet_envs
    args = Arguments(agent_rl=None, env=None, gpu_id=0)
    args.agent_rl = agent.AgentTD3
    args.env = prep_env(env=gym.make('ReacherBulletEnv-v0'))
    args.net_dim = 2 ** 7  # change a default hyper-parameters
    args.if_per = True
    args.break_step = int(2e20)  # (4e4) 8e5, UsedTime: (300s) 700s
    # train_and_evaluate(args)
    train_and_evaluate__multiprocessing(args)
    exit(0)
`

结果：
### **1.TD多进程采样：**

| env_name: ReacherBulletEnv-v0, action space: Continuous
| state_dim: 9, action_dim: 2, action_max: 1.0, target_reward: 18.0
| GPU id: 0, cwd: ./AgentTD3/ReacherBulletEnv-v0_0
| Remove history
ID      Step      MaxR |    avgR      stdR       objA      objC
0   0.00e+00    -10.10 |
0   1.43e+04     -7.85 |
0   2.82e+04     -5.65 |
0   8.76e+04     -4.07 |
0   9.73e+04     -4.07 |   -4.07     11.89     -24.86      0.36
0   1.08e+05     -1.77 |
0   3.60e+05      0.77 |
0   3.99e+05      0.77 |   -3.40     16.09     -42.21      0.26
0   3.99e+05      1.90 |
0   7.06e+05      5.36 |
0   9.37e+05      5.36 |    4.25     12.76     -47.56      0.28
0   1.70e+06      5.36 |   -2.09     12.38     -48.50      0.60
0   1.96e+06      6.72 |
0   2.33e+06      8.20 |
0   2.38e+06      9.19 |
0   2.69e+06      9.19 |    8.90      2.45     -47.49      0.28
0   2.96e+06     11.88 |
0   3.90e+06     11.88 |   11.62     13.27     -45.94      0.56
0   5.28e+06     11.88 |   -3.66     13.65     -48.06      1.01
0   6.66e+06     11.88 |   -3.82      6.94     -44.21      0.12
0   7.97e+06     11.88 |    0.21     11.91     -44.42      0.48
0   9.22e+06     11.88 |   -0.14     11.85     -45.38      0.37
0   1.05e+07     11.88 |    2.54      9.46     -45.15      1.30
0   1.18e+07     11.88 |   -0.68      5.93     -45.92      0.56
0   1.31e+07     11.88 |    1.24     16.31     -49.12      0.48
0   1.43e+07     11.88 |    5.22      5.86     -49.60      0.30
0   1.57e+07     11.88 |   -5.00      7.89     -54.07      0.23
0   1.69e+07     11.88 |    1.71      4.36     -58.06      0.57
0   1.82e+07     11.88 |   -1.90      9.13     -59.05      0.17
0   1.95e+07     11.88 |    1.43      9.63     -62.79      0.79
0   2.08e+07     11.88 |   -3.46     17.30     -66.44      0.22
0   2.22e+07     11.88 |    1.14     16.78     -73.18      0.29
0   2.34e+07     11.88 |    5.69     10.08     -77.96      0.22
0   2.47e+07     11.88 |    4.17      6.88     -77.39      0.26
0   2.60e+07     11.88 |   -6.64      8.83     -78.47      0.30
0   2.73e+07     11.88 |    3.75      7.19     -80.25      0.47
0   2.86e+07     11.88 |   -3.96     11.57     -85.49      0.90
0   2.99e+07     11.88 |    9.32      9.39     -88.90      0.66
0   3.13e+07     11.88 |   -2.83     10.20     -92.14      1.65
0   3.26e+07     11.88 |    1.84      6.93    -105.22      0.51
0   3.39e+07     11.88 |  -17.75      8.98    -111.59      2.63
0   3.52e+07     11.88 |   -2.34     16.34    -117.58      0.64
0   3.65e+07     11.88 |   -7.35      6.63    -115.69      0.55
0   3.79e+07     11.88 |   -5.29     14.56    -121.52      0.81
0   3.92e+07     11.88 |   -4.89      5.31    -131.59      4.22
0   4.06e+07     11.88 |   -4.45     10.53    -153.78      2.67
0   4.19e+07     11.88 |  -11.50      7.71    -158.07      4.67
0   4.32e+07     11.88 |   -2.23      9.39    -168.74      1.33
0   4.46e+07     11.88 |   -8.04     18.61    -170.51      1.51
0   4.59e+07     11.88 |   -7.31      8.35    -178.57      1.90
0   4.72e+07     11.88 |  -11.84     19.20    -192.88      1.71
0   4.85e+07     11.88 |   -7.40     17.81    -208.41      6.31
0   4.99e+07     11.88 |   -1.76      5.93    -198.52      2.78
0   5.12e+07     11.88 |  -15.18     15.98    -194.09      2.66
0   5.25e+07     11.88 |  -13.77     15.55    -202.15      3.91
0   5.38e+07     11.88 |  -26.60     13.45    -222.04      1.26
0   5.51e+07     11.88 |  -11.84      9.49    -236.06      4.97
0   5.64e+07     11.88 |   -8.83     10.41    -243.08      4.94
0   5.77e+07     11.88 |  -11.31     11.26    -246.36      1.78
0   5.90e+07     11.88 |  -18.45     15.43    -275.48      2.49
0   6.03e+07     11.88 |   -6.29      5.43    -282.37      1.72
0   6.17e+07     11.88 |   -4.93     21.10    -273.88      1.70
0   6.30e+07     11.88 |   -9.25      9.82    -259.61      4.30
0   6.43e+07     11.88 |  -10.35     11.50    -253.55      9.75
0   6.56e+07     11.88 |    0.13      8.25    -247.03      1.66
0   6.69e+07     11.88 |  -13.06      5.25    -247.55      2.76
0   6.83e+07     11.88 |   -9.79      5.36    -247.33      3.52
0   6.96e+07     11.88 |    5.66      4.07    -252.52      2.16
0   7.09e+07     11.88 |   -1.53      8.23    -268.19      4.37
0   7.22e+07     11.88 |  -14.27      3.96    -276.23      2.19
0   7.35e+07     11.88 |   -4.26     10.23    -284.44      2.40
0   7.48e+07     11.88 |    0.49     12.77    -275.76      8.22
0   7.62e+07     11.88 |  -10.07     11.53    -260.85      1.48
0   7.75e+07     11.88 |   -8.09     12.05    -251.48      3.94
0   7.87e+07     11.88 |   -9.14     11.66    -249.72      3.76
0   8.00e+07     11.88 |   -6.14      5.90    -255.89      3.27
0   8.13e+07     11.88 |   -4.16     11.02    -261.17      4.34
0   8.27e+07     11.88 |  -27.61     14.25    -261.14      2.33
0   8.40e+07     11.88 |   -7.61      8.58    -278.24      4.18
0   8.53e+07     11.88 |  -15.42     11.71    -281.53      1.50
0   8.65e+07     11.88 |  -11.29      6.98    -275.23      1.72
0   8.78e+07     11.88 |    4.31      8.42    -272.53      9.04
0   8.92e+07     11.88 |   -9.40     11.06    -265.66      1.89
0   9.05e+07     11.88 |   -6.10      6.76    -268.57      5.88
0   9.18e+07     11.88 |   -3.23     10.29    -267.12      6.73
0   9.31e+07     11.88 |   -7.54     14.40    -265.97      2.29
0   9.44e+07     11.88 |  -15.50     10.56    -271.80      2.21
0   9.57e+07     11.88 |   -1.60      5.91    -270.91      3.70
0   9.70e+07     11.88 |   -5.93      5.25    -251.78      3.92
0   9.83e+07     11.88 |   -4.38      8.28    -251.12      2.05
0   9.96e+07     11.88 |   -2.56      6.56    -243.03      3.16
0   1.01e+08     11.88 |  -11.45     14.67    -224.15      6.82
0   1.02e+08     11.88 |    4.85     12.31    -223.53      3.83
0   1.03e+08     11.88 |   -5.88      8.79    -226.65      1.35
0   1.05e+08     11.88 |  -23.09     11.19    -231.49      1.83
0   1.06e+08     11.88 |   -5.30     15.58    -238.79      3.96
### **2.PER-TD多进程采样：**
| env_name: ReacherBulletEnv-v0, action space: Continuous
| state_dim: 9, action_dim: 2, action_max: 1.0, target_reward: 18.0
| GPU id: 0, cwd: ./AgentTD3/ReacherBulletEnv-v0_0
| Remove history
ID      Step      MaxR |    avgR      stdR       objA      objC
0   0.00e+00    -82.26 |
0   1.54e+03    -40.41 |
0   3.07e+03    -28.69 |
0   3.38e+04    -28.69 |  -47.06     35.06      -9.55      0.01
0   3.38e+04    -27.13 |
0   3.99e+04    -26.46 |
0   4.66e+04     -5.36 |
0   7.83e+04     -4.57 |
0   1.41e+05     -4.57 |   -5.14      6.13     -22.66      0.02
0   2.54e+05     -3.79 |
0   3.23e+05     -3.79 |  -13.48     10.13     -36.54      0.02
0   5.78e+05     -3.79 |  -10.26      5.54     -41.82      0.02
0   9.06e+05     -3.79 |  -14.72     17.08     -50.86      0.01
0   1.24e+06     -3.15 |
0   1.31e+06     -3.15 |   -9.57     13.58     -50.78      0.04
0   1.46e+06     -2.79 |
0   1.50e+06     -1.90 |
0   1.70e+06      2.44 |
0   1.78e+06      2.44 |    0.87     13.02     -51.04      0.00
0   2.33e+06      2.44 |    1.85     13.99     -49.51      0.01
0   2.96e+06      2.44 |    1.44     10.03     -48.75      0.03
0   3.66e+06      2.44 |   -1.40     13.50     -48.18      0.01
0   3.66e+06      7.49 |
0   4.42e+06      7.49 |  -19.39     10.65     -47.56      0.03
0   5.21e+06      7.49 |  -24.37      7.01     -48.55      0.01
0   6.00e+06      7.49 |   -1.85     12.02     -48.25      0.04
0   6.79e+06      7.49 |   -6.57     14.84     -44.79      0.05
0   7.51e+06      7.49 |   -4.87      9.16     -42.40      0.00
0   8.30e+06      7.49 |   -8.19     14.97     -39.73      0.01
0   9.02e+06      7.49 |   -2.11      9.82     -36.60      0.00
0   9.74e+06      7.49 |   -9.80     14.82     -34.79      0.01
0   1.05e+07      7.49 |   -4.22     13.06     -32.31      0.00
0   1.12e+07      7.49 |    6.36      9.31     -30.57      0.00
0   1.20e+07      7.49 |  -15.97     27.14     -28.42      0.01
0   1.28e+07      7.49 |    1.15     11.56     -26.45      0.00
0   1.35e+07      7.49 |  -12.16     16.07     -25.51      0.00
0   1.42e+07      7.49 |   -0.04      7.06     -25.17      0.00
0   1.50e+07      7.49 |   -3.24      5.74     -23.80      0.00
0   1.57e+07      7.49 |   -7.28     10.18     -22.47      0.00
0   1.64e+07      7.49 |   -2.29      7.68     -21.51      0.01
0   1.72e+07      7.49 |    5.84      9.26     -21.82      0.00
0   1.77e+07      7.55 |
0   1.79e+07      7.55 |   -6.18     11.19     -18.97      0.00
0   1.87e+07      7.55 |    5.26      6.50     -18.74      0.00
0   1.94e+07      7.55 |   -2.79     14.56     -18.77      0.00
0   2.01e+07      7.55 |    0.82     17.24     -18.49      0.00
0   2.08e+07      7.55 |   -1.05     10.40     -18.13      0.00
0   2.15e+07      7.55 |    3.58      3.82     -17.57      0.00
0   2.22e+07     10.12 |
0   2.22e+07     10.12 |   10.12     11.29     -16.78      0.01
0   2.29e+07     10.12 |    8.16     11.75     -15.61      0.00
0   2.37e+07     10.12 |  -10.22      9.42     -16.38      0.00
0   2.44e+07     10.12 |   -0.79      6.49     -16.43      0.00
0   2.52e+07     10.12 |   -8.22     14.32     -16.36      0.01
0   2.59e+07     10.12 |    8.78      8.40     -18.02      0.00
0   2.66e+07     10.12 |   -8.32      9.20     -17.81      0.00
0   2.73e+07     10.12 |   -5.07     16.60     -17.76      0.00
0   2.81e+07     10.12 |    3.78      5.52     -18.57      0.00
0   2.89e+07     10.12 |    4.71     14.23     -18.24      0.00
0   2.96e+07     10.12 |    7.89      5.64     -17.21      0.00
0   3.03e+07     10.12 |    6.07      9.17     -17.13      0.00
0   3.11e+07     10.12 |   -8.40      8.64     -17.91      0.00
0   3.19e+07     10.12 |  -11.56     16.94     -16.70      0.00
0   3.26e+07     10.12 |   -6.52      7.40     -17.99      0.00
0   3.33e+07     10.12 |   -7.13     16.43     -18.93      0.00
0   3.40e+07     10.12 |  -17.30     16.57     -17.44      0.00
0   3.48e+07     10.12 |    1.61      4.25     -17.65      0.00
0   3.55e+07     10.12 |    8.68     10.02     -16.84      0.00
0   3.62e+07     10.12 |   -4.46     15.80     -15.85      0.00
0   3.69e+07     10.12 |    2.16     14.67     -15.87      0.00
0   3.76e+07     11.44 |
0   3.77e+07     11.44 |   11.44      6.85     -15.58      0.00
0   3.77e+07     13.48 |
0   3.84e+07     13.48 |    3.14     16.45     -15.35      0.00
0   3.91e+07     13.48 |    4.12      9.11     -16.68      0.00
0   3.98e+07     13.48 |    5.16     11.80     -18.17      0.01
0   4.06e+07     13.48 |    5.58     13.35     -18.33      0.00
0   4.13e+07     13.48 |    5.82      5.88     -15.60      0.00
0   4.21e+07     13.48 |   -0.06      4.04     -16.66      0.00
0   4.29e+07     13.48 |    7.73     11.03     -17.12      0.00
0   4.36e+07     13.48 |    1.72     12.14     -18.83      0.00
0   4.37e+07     15.32 |
0   4.44e+07     15.32 |    2.18      5.95     -19.44      0.00
0   4.51e+07     15.32 |   10.86      9.65     -18.77      0.00
0   4.59e+07     15.32 |    7.14      2.35     -18.03      0.00
0   4.67e+07     15.32 |    8.71     17.61     -16.94      0.00
0   4.74e+07     15.32 |    6.70     16.31     -16.68      0.00
0   4.81e+07     15.32 |    6.84      9.15     -15.80      0.00
0   4.88e+07     15.32 |    4.99      8.43     -17.52      0.00
0   4.96e+07     15.32 |    5.73      8.35     -17.41      0.00
0   5.03e+07     15.32 |    3.70     10.32     -17.46      0.00
0   5.10e+07     15.32 |   11.55     14.72     -17.52      0.00
0   5.18e+07     15.32 |    9.70     10.35     -16.66      0.00
0   5.25e+07     15.32 |   -1.65      9.02     -17.77      0.01
0   5.32e+07     15.32 |    0.08     22.30     -17.88      0.00
0   5.40e+07     15.32 |   -2.88     13.98     -18.18      0.00
0   5.47e+07     15.32 |    5.82     12.02     -17.25      0.00
0   5.55e+07     15.32 |    1.18     20.77     -17.31      0.00
0   5.62e+07     15.32 |   -7.66     10.28     -16.70      0.00
0   5.69e+07     15.32 |    1.72     14.23     -17.42      0.00
0   5.76e+07     15.32 |   -2.25     23.39     -16.46      0.00
0   5.84e+07     15.32 |    9.97      9.98     -17.61      0.00
0   5.91e+07     15.32 |   -2.91     15.04     -17.81      0.01
0   5.98e+07     15.32 |   -4.11     15.62     -17.10      0.00
0   6.06e+07     15.32 |    4.32     14.34     -16.75      0.00
0   6.13e+07     15.32 |   -1.51     15.48     -16.55      0.00
0   6.20e+07     15.32 |    7.75      5.56     -17.56      0.00
0   6.28e+07     15.32 |    4.61      6.68     -16.60      0.00
0   6.35e+07     15.32 |   13.36     10.35     -16.19      0.00
0   6.43e+07     15.32 |    7.60      3.03     -15.55      0.00
0   6.51e+07     15.32 |    8.59     10.02     -15.27      0.00
0   6.58e+07     15.32 |    8.14     11.42     -16.50      0.00
0   6.66e+07     15.32 |    6.88      9.76     -15.77      0.00
0   6.73e+07     15.32 |    8.32      9.10     -18.09      0.00
0   6.80e+07     15.32 |   12.38      7.03     -16.16      0.00
0   6.88e+07     15.32 |   10.30      5.03     -17.93      0.00
0   6.95e+07     15.32 |   14.88      7.86     -19.79      0.00
0   7.02e+07     15.32 |    5.16      9.44     -17.54      0.00
0   7.10e+07     15.32 |    2.74      5.30     -19.25      0.00
0   7.18e+07     15.32 |    6.66      2.19     -18.19      0.00
0   7.25e+07     15.32 |    2.18      7.87     -17.48      0.00
0   7.33e+07     15.32 |    3.96      4.82     -17.85      0.00
0   7.41e+07     15.32 |   11.59      7.95     -18.21      0.00
0   7.48e+07     15.32 |   -1.74     13.36     -20.08      0.00
0   7.56e+07     15.32 |   -6.41      9.26     -17.98      0.00
0   7.63e+07     15.32 |   -4.68      7.34     -16.36      0.00
0   7.71e+07     15.32 |   -5.58     12.27     -16.22      0.00
0   7.79e+07     15.32 |   14.70     11.23     -17.51      0.00
0   7.86e+07     15.32 |    3.16     13.68     -18.45      0.00
0   7.93e+07     15.32 |    6.58     14.01     -18.27      0.00
0   8.01e+07     15.32 |    5.59      5.57     -18.51      0.00
0   8.08e+07     15.32 |    8.52      6.77     -17.59      0.00
0   8.15e+07     15.32 |    4.84     14.45     -18.88      0.00
0   8.23e+07     15.32 |   11.37      3.79     -17.24      0.00
0   8.30e+07     15.32 |    3.30      3.43     -16.87      0.00
0   8.37e+07     15.32 |    3.27     11.69     -16.64      0.01
0   8.44e+07     15.32 |   -2.40      3.00     -17.26      0.00
0   8.52e+07     15.32 |    6.13      7.39     -16.71      0.00
0   8.59e+07     15.32 |    1.57     11.31     -16.94      0.00
0   8.66e+07     15.32 |    8.16     13.69     -17.78      0.00
0   8.73e+07     15.32 |    9.96      7.20     -17.19      0.00
0   8.80e+07     15.32 |    3.51      8.96     -17.52      0.00
0   8.88e+07     15.32 |    0.89      7.73     -18.59      0.00
0   8.96e+07     15.32 |   -4.60     10.80     -18.42      0.00
0   9.03e+07     15.32 |    2.77      2.31     -18.81      0.00
0   9.11e+07     15.32 |    1.78     14.37     -20.30      0.00
0   9.18e+07     15.32 |    9.88     18.90     -19.80      0.00
0   9.26e+07     15.32 |    1.70      3.50     -19.58      0.00
0   9.33e+07     15.32 |    7.04     10.45     -19.69      0.00
0   9.41e+07     15.32 |    8.00      8.88     -20.24      0.00
0   9.48e+07     15.32 |   -1.02      3.63     -19.72      0.00
0   9.55e+07     15.32 |    9.17      4.79     -18.80      0.00
0   9.63e+07     15.32 |    6.66      1.71     -18.79      0.00
0   9.70e+07     15.32 |    8.72      9.38     -18.98      0.00
0   9.78e+07     15.32 |    1.45      7.67     -17.95      0.00
0   9.86e+07     15.32 |    6.23      3.88     -17.47      0.00
0   9.93e+07     15.32 |    3.18     14.98     -18.80      0.00
0   1.00e+08     15.32 |    2.58      9.43     -18.13      0.00
0   1.01e+08     15.32 |   -0.76      7.36     -17.07      0.00
0   1.02e+08     15.32 |    7.03      9.50     -15.19      0.00
0   1.02e+08     15.32 |   -5.05      4.11     -15.59      0.00
0   1.03e+08     15.32 |    6.07      2.02     -14.15      0.00
0   1.04e+08     15.32 |   -0.82     10.71     -14.83      0.00
0   1.05e+08     15.32 |    5.31      6.86     -14.52      0.00
0   1.05e+08     15.32 |    9.23      5.52     -16.10      0.00
0   1.06e+08     15.32 |    7.46     11.61     -15.63      0.00
### **3.PER-TD单进程采样：**
| env_name: ReacherBulletEnv-v0, action space: Continuous
| state_dim: 9, action_dim: 2, action_max: 1.0, target_reward: 18.0
| GPU id: 0, cwd: ./AgentTD3/ReacherBulletEnv-v0_0
| Remove history
ID      Step      MaxR |    avgR      stdR       objA      objC
0   0.00e+00   -108.44 |
0   5.12e+02    -76.37 |
0   1.54e+03    -28.66 |
0   3.07e+03    -18.15 |
0   1.84e+04    -18.15 |  -60.78     60.25      -0.99      0.01
0   3.99e+04    -14.41 |
0   7.83e+04    -14.41 |  -37.73     21.12      -5.30      0.00
0   1.08e+05     -6.68 |
0   1.66e+05     -6.68 |  -27.27      6.77     -10.86      0.00
0   3.05e+05     -6.68 |  -10.18      7.74     -14.14      0.00
0   4.62e+05     -6.68 |  -19.32     19.30     -16.43      0.01
0   6.02e+05     -4.85 |
0   6.53e+05     -4.85 |  -13.96     20.42     -16.78      0.00
0   7.60e+05     -4.82 |
0   7.88e+05     -3.39 |
0   8.76e+05     -3.39 |   -8.78     12.05     -19.29      0.01
0   1.13e+06     -3.39 |   -5.52      9.83     -21.69      0.00
0   1.42e+06     -3.39 |  -24.95     26.79     -21.36      0.00
0   1.50e+06     -1.66 |
0   1.74e+06     -1.66 |   -9.27     15.68     -23.47      0.02
0   2.10e+06     -1.66 |   -6.94     11.95     -22.23      0.01
0   2.48e+06     -1.66 |  -17.45     16.24     -25.86      0.01
0   2.90e+06     -1.66 |  -12.96     19.11     -25.28      0.00
0   2.90e+06     -0.41 |
0   3.36e+06     -0.41 |   -5.14      3.71     -22.33      0.02
0   3.72e+06      2.85 |
0   3.84e+06      2.85 |    0.66      7.30     -24.18      0.00
0   3.90e+06      3.04 |
0   4.36e+06      3.04 |   -0.48     19.45     -22.43      0.01
0   4.88e+06      3.04 |    2.39      1.85     -22.99      0.00
0   5.41e+06      3.04 |  -10.69     13.13     -23.70      0.00
0   5.93e+06      3.04 |   -4.95      7.43     -25.89      0.00
0   6.46e+06      3.04 |   -5.51     10.70     -23.51      0.00
0   6.99e+06      3.04 |   -2.70     10.48     -21.52      0.01
0   7.51e+06      3.04 |    0.25      5.72     -23.25      0.00
0   8.04e+06      3.04 |   -9.81      8.84     -22.91      0.00
0   8.56e+06      3.04 |   -3.22     12.03     -22.38      0.00
0   8.69e+06      6.04 |
0   9.09e+06      6.04 |  -10.16     14.60     -21.24      0.00
0   9.61e+06      6.04 |   -8.32      5.61     -20.19      0.00
0   1.01e+07      6.04 |    1.09      6.90     -21.84      0.01
0   1.07e+07      6.04 |    2.13     11.20     -20.23      0.00
0   1.12e+07      6.04 |   -4.09      7.21     -21.58      0.00
0   1.17e+07      6.04 |   -1.79     17.64     -20.62      0.01
0   1.22e+07      6.04 |    5.63      6.50     -20.43      0.00
0   1.28e+07      6.04 |   -0.88     12.76     -20.68      0.00
0   1.33e+07      6.04 |   -1.54     10.20     -20.54      0.01
0   1.38e+07      6.04 |    5.48      8.75     -21.10      0.00
0   1.43e+07      6.04 |    3.36      7.71     -20.91      0.00
0   1.49e+07      6.04 |   -4.74     14.32     -19.93      0.00
0   1.54e+07      6.04 |    2.12      8.51     -20.00      0.00
0   1.59e+07      6.04 |    0.73     10.73     -19.49      0.00
0   1.62e+07      7.59 |
0   1.64e+07      7.59 |    5.53     11.91     -20.11      0.00
0   1.70e+07      7.59 |   -3.61     20.40     -20.31      0.00
0   1.75e+07      7.59 |    3.27     18.27     -19.23      0.00
0   1.80e+07      7.59 |   -6.00      9.44     -19.72      0.00
0   1.86e+07      7.59 |    3.16     13.26     -17.93      0.00
0   1.90e+07      8.78 |
0   1.91e+07      9.27 |
0   1.91e+07      9.27 |    9.27      7.65     -17.92      0.00
0   1.93e+07     10.18 |
0   1.97e+07     10.18 |    3.66     13.78     -17.55      0.00
0   2.02e+07     10.18 |    8.18     16.32     -18.26      0.00
0   2.07e+07     10.18 |    3.30     11.10     -18.81      0.00
0   2.12e+07     10.18 |    7.12      9.74     -18.72      0.01
0   2.18e+07     10.18 |    8.81      9.32     -18.97      0.00
0   2.23e+07     10.18 |    5.43      6.14     -19.20      0.00
0   2.28e+07     10.18 |    8.58      6.92     -19.43      0.01
0   2.33e+07     10.18 |   -4.08      7.70     -19.78      0.00
0   2.39e+07     10.18 |   -4.40     11.59     -18.50      0.00
0   2.43e+07     10.71 |
0   2.44e+07     10.71 |    1.13     10.92     -18.75      0.00
0   2.49e+07     10.71 |   -2.83     13.81     -18.54      0.00
0   2.54e+07     10.71 |    7.75      7.07     -18.11      0.00
0   2.60e+07     10.71 |    7.44      8.56     -18.92      0.00
0   2.65e+07     10.71 |   -1.40     11.68     -18.24      0.02
0   2.70e+07     10.71 |    6.84      7.25     -19.07      0.00
0   2.75e+07     10.71 |   -3.50     15.53     -18.60      0.00
0   2.81e+07     10.71 |   -4.66      9.88     -19.57      0.00
0   2.86e+07     10.71 |    9.71      5.44     -19.82      0.00
0   2.91e+07     10.71 |    9.92     10.64     -20.11      0.00
0   2.96e+07     10.71 |    3.38     14.57     -21.15      0.00
0   3.02e+07     10.71 |    3.75     11.34     -19.87      0.00
0   3.07e+07     10.71 |    5.64     10.23     -19.33      0.00
0   3.12e+07     10.71 |    1.11     13.99     -20.95      0.00
0   3.17e+07     10.71 |   10.43     11.07     -18.58      0.00
0   3.23e+07     10.71 |   -2.36      5.66     -19.59      0.00
0   3.28e+07     10.71 |   -1.72      8.13     -19.41      0.00
0   3.33e+07     10.71 |   -3.32      8.86     -19.02      0.00
0   3.39e+07     10.71 |    9.48      5.75     -21.16      0.00
0   3.44e+07     10.71 |   -1.88     10.72     -20.38      0.01
0   3.49e+07     10.71 |   -7.58     10.15     -20.53      0.00
0   3.54e+07     10.71 |    6.23     14.53     -20.68      0.01
0   3.60e+07     10.71 |    7.10     11.12     -19.25      0.00
0   3.63e+07     11.26 |
0   3.65e+07     11.26 |    4.69     13.52     -20.54      0.00
0   3.70e+07     11.26 |    5.34      9.95     -19.40      0.00
0   3.75e+07     11.26 |    7.86     10.18     -19.32      0.00
0   3.77e+07     11.97 |
0   3.78e+07     13.08 |
0   3.81e+07     13.08 |    0.83     15.81     -19.37      0.01
0   3.86e+07     13.08 |    8.15      9.48     -19.74      0.00
0   3.86e+07     13.67 |
0   3.91e+07     13.67 |   13.44     11.93     -19.90      0.01
0   3.96e+07     13.67 |   -3.32     11.65     -20.51      0.01
0   4.02e+07     13.67 |    9.76      5.46     -20.51      0.00
0   4.07e+07     13.67 |   -4.15      8.79     -21.07      0.00
0   4.12e+07     13.67 |   -2.62     18.20     -21.53      0.00
0   4.17e+07     13.67 |    5.96     10.99     -20.68      0.01
0   4.23e+07     13.67 |    5.71     10.47     -19.68      0.00
0   4.28e+07     13.67 |    2.90      7.50     -19.27      0.01
0   4.33e+07     13.67 |   12.74      9.68     -18.27      0.00
0   4.38e+07     13.67 |    0.88      7.08     -17.70      0.01
0   4.44e+07     13.67 |    2.11      9.37     -17.67      0.00
0   4.49e+07     13.67 |    4.49     11.51     -18.18      0.00
0   4.54e+07     13.67 |    1.25     15.71     -16.99      0.00
0   4.59e+07     13.67 |   11.52     12.22     -18.38      0.00
0   4.65e+07     13.67 |    7.50     10.59     -18.89      0.00
0   4.70e+07     13.67 |   -8.10      9.76     -18.07      0.00
0   4.75e+07     13.67 |    2.20      6.68     -19.09      0.01
0   4.80e+07     13.67 |    7.97     15.85     -19.15      0.00
0   4.86e+07     13.67 |    2.01      8.55     -18.93      0.01
0   4.91e+07     13.67 |   -4.85     27.60     -19.18      0.00
0   4.96e+07     13.67 |   -0.68     15.46     -20.17      0.00
0   5.01e+07     13.67 |  -10.46      5.23     -21.88      0.00
0   5.07e+07     13.67 |    2.75     12.34     -20.27      0.00
0   5.12e+07     13.67 |   -4.41     13.99     -20.28      0.00
0   5.17e+07     13.67 |  -21.14     15.03     -20.23      0.01
0   5.22e+07     13.67 |   11.92      3.26     -19.83      0.00
0   5.28e+07     13.67 |   -2.38      8.57     -20.37      0.00
0   5.33e+07     13.67 |    8.12      6.58     -18.99      0.00
0   5.38e+07     13.67 |    9.07      7.87     -18.57      0.01
0   5.43e+07     13.67 |   13.58     11.30     -17.92      0.00
0   5.49e+07     13.67 |    6.41      6.55     -18.40      0.01
0   5.54e+07     13.67 |    8.29     13.24     -18.80      0.00
0   5.58e+07     14.10 |
0   5.59e+07     14.10 |    8.90      5.66     -17.08      0.00
0   5.64e+07     14.10 |  -12.28     10.90     -17.05      0.00
0   5.70e+07     14.10 |    7.47      4.32     -17.49      0.00
0   5.75e+07     14.10 |   -3.43     17.19     -16.35      0.00
0   5.80e+07     14.10 |    4.79     23.01     -16.38      0.01
0   5.85e+07     14.10 |    4.02      9.37     -16.41      0.00
0   5.91e+07     14.10 |    5.73     10.91     -16.37      0.00
0   5.96e+07     14.10 |   11.49      9.71     -16.35      0.00
0   6.01e+07     14.10 |   13.39     11.38     -17.35      0.00
0   6.07e+07     14.10 |   -0.27     19.96     -17.96      0.00
0   6.12e+07     14.10 |   -1.00      5.45     -16.78      0.00
0   6.17e+07     14.10 |   -0.79      9.01     -16.94      0.00
0   6.22e+07     14.10 |   -0.31     18.68     -17.75      0.00
0   6.28e+07     14.10 |    9.00      6.02     -16.67      0.00
0   6.33e+07     14.10 |   13.01     12.57     -16.39      0.00
0   6.38e+07     14.10 |    6.12      8.29     -15.87      0.00
0   6.43e+07     14.10 |    6.69      2.11     -15.18      0.00
0   6.49e+07     14.10 |   10.78      6.87     -15.20      0.00
0   6.50e+07     15.77 |
0   6.54e+07     15.77 |   -3.02      9.39     -14.73      0.00
0   6.59e+07     15.77 |   10.06      6.76     -15.10      0.00
0   6.64e+07     15.77 |   12.34     10.59     -16.05      0.00
0   6.70e+07     15.77 |    0.08      5.98     -15.74      0.00
0   6.75e+07     15.77 |    1.02     13.68     -15.65      0.00
0   6.80e+07     15.77 |   -2.97      5.67     -15.22      0.00
0   6.85e+07     15.77 |   14.21     11.19     -15.73      0.00
0   6.91e+07     15.77 |   15.55     14.62     -15.54      0.00
0   6.96e+07     15.77 |    4.24     10.37     -16.38      0.00
0   7.01e+07     15.77 |    0.91      7.39     -15.95      0.00
0   7.06e+07     15.77 |    9.52      5.90     -16.64      0.01
0   7.12e+07     15.77 |   11.41      8.42     -16.50      0.00
0   7.16e+07     17.69 |
0   7.17e+07     17.69 |   17.69     11.86     -18.01      0.00
0   7.22e+07     17.69 |    9.22      8.81     -17.35      0.00
0   7.27e+07     17.69 |   12.18     10.10     -18.80      0.00
0   7.33e+07     17.69 |   11.52      9.74     -17.54      0.00
0   7.38e+07     17.69 |   13.50      3.30     -18.49      0.00
0   7.43e+07     17.69 |    2.79      7.31     -21.80      0.00
0   7.48e+07     17.69 |    1.74     12.94     -21.70      0.00
0   7.54e+07     17.69 |   14.91      7.36     -20.25      0.00
0   7.59e+07     17.69 |    7.79     13.37     -19.73      0.01
0   7.64e+07     17.69 |   12.50      7.74     -17.73      0.00
0   7.70e+07     17.69 |    9.95      7.25     -19.03      0.00
0   7.75e+07     17.69 |    9.06     12.15     -17.58      0.00
0   7.81e+07     17.69 |    9.64     15.94     -17.50      0.00
0   7.86e+07     17.69 |    8.14      6.17     -17.08      0.00
0   7.92e+07     17.69 |   -3.08      6.57     -16.25      0.00
0   7.97e+07     17.69 |    5.08      7.86     -15.45      0.00
0   8.02e+07     17.69 |   10.09     15.75     -15.79      0.00
0   8.08e+07     17.69 |    5.42     13.10     -16.51      0.00
0   8.13e+07     17.69 |   11.40     10.01     -15.84      0.00
0   8.18e+07     17.69 |   10.24     10.64     -17.75      0.00
0   8.23e+07     17.69 |    3.70      6.70     -17.70      0.00
0   8.29e+07     17.69 |    5.60     14.54     -17.53      0.00
0   8.34e+07     17.69 |   14.39     11.32     -17.28      0.00
0   8.39e+07     17.69 |    9.17      7.13     -16.80      0.00
0   8.44e+07     17.69 |    6.55      6.85     -17.55      0.00
0   8.50e+07     17.69 |    1.38      9.58     -18.17      0.00
0   8.55e+07     17.69 |    3.72     12.09     -16.58      0.00
0   8.60e+07     17.69 |    7.57      6.10     -16.78      0.00
0   8.65e+07     17.69 |   17.34      7.62     -16.15      0.00
0   8.71e+07     17.69 |   16.50      4.79     -15.37      0.00
0   8.76e+07     17.69 |   17.30      7.89     -15.78      0.00
0   8.81e+07     17.69 |   10.49      3.69     -16.31      0.00
0   8.86e+07     17.69 |   10.11     11.13     -16.00      0.00
0   8.92e+07     17.69 |    8.42     10.29     -15.54      0.00
0   8.98e+07     17.69 |    1.95     15.05     -14.76      0.00
0   9.03e+07     17.69 |   11.59     11.45     -15.08      0.00
0   9.08e+07     17.69 |    9.55     10.93     -16.19      0.00
0   9.13e+07     17.69 |    4.08      6.38     -18.98      0.00
0   9.19e+07     17.69 |   11.28      9.53     -19.57      0.00
0   9.24e+07     17.69 |   10.58      7.03     -20.96      0.00
